### PR TITLE
feature: support for custom snap-ins + added several other common snap-ins

### DIFF
--- a/DRSAT/Program.cs
+++ b/DRSAT/Program.cs
@@ -1,70 +1,96 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 
-namespace DRSAT {
-    internal class Program {
+namespace DRSAT
+{
+    internal class Program
+    {
+        private static readonly Dictionary<string, string> _consoles = new Dictionary<string, string>()
+        {
+            { "adsi", @"""C:\Windows\System32\adsiedit.msc""" },
+            { "aduc", @"""C:\Windows\System32\dsa.msc""" },
+            { "cert", @"""C:\Windows\System32\certsrv.msc""" },
+            { "dns", @"""C:\Windows\System32\dnsmgmt.msc""" },
+            { "gpo", @"""C:\Windows\System32\gpmc.msc""" },
+            { "template", @"""C:\Windows\System32\certtmpl.msc""" },
+        };
 
+        private static readonly string _mmcPath = @"C:\Windows\System32\mmc.exe";
+        private static readonly string _gpmePath = @"""C:\Windows\System32\gpme.msc""";
 
-        static string AddQuotesIfNeeded(string arg) {
+        private static readonly string _programHelp = @"[!] Usage: DRSAT.exe adsi|aduc|cert|dns|gpo|template|custom target.domain [C:\Windows\System32\custom.msc]";
+
+        private static string AddQuotesIfNeeded(string arg)
+        {
             if (arg.StartsWith("/gpobject"))
+            {
                 return $@"/gpobject:""{arg.Substring(10)}""";
-            else
-                return arg;
-        }
-
-        static void Main(string[] args) {
-          
-            string targetDomain = null;
-            string channelName = null;
-            string commandLine;
-            string domainController = "";
-
-            if (args.Length >= 2) {
-
-                if (args[1].ToLower().StartsWith("/gpobject:")) {
-
-                    commandLine = args.Aggregate(@"""C:\WINDOWS\SYSTEM32\GPME.MSC""",
-                    (current, next) => $@"{current} {AddQuotesIfNeeded(next)}");
-                
-                    Uri uri = new Uri(args[1].Substring(10));
-                    domainController = uri.Host;
-                    targetDomain = domainController.Substring(domainController.IndexOf('.') + 1);
-
-                    Console.WriteLine($"[=] Detected GPO edit action - DC={domainController}, TargetDomain={targetDomain}");
-                    
-                } else{
-
-                    targetDomain = args[1];
-
-                    if (args[0] == "cert") {
-                        commandLine = commandLine = @"""C:\WINDOWS\SYSTEM32\certsrv.msc""";
-                    } else if(args[0] == "gpo") {
-                        commandLine = @"""C:\WINDOWS\SYSTEM32\GPMC.MSC""";
-                    } else if (args[0] == "template") {
-                        commandLine = @"""C:\WINDOWS\SYSTEM32\certtmpl.msc""";
-                    } else {
-                        Console.WriteLine("[!] Usage: DRSAT cert|gpo|template target_domain");
-                        return;
-                    }
-                }                
-            
-            } else {
-                Console.WriteLine("[!] Usage: DRSAT cert|gpo|template target_domain");
-                return;
             }
 
-            EasyHook.RemoteHooking.IpcCreateServer<DRSATHook.ServerRpc>(ref channelName, System.Runtime.Remoting.WellKnownObjectMode.Singleton);
+            return arg;
+        }
+
+        private static void PrintHelpAndExit()
+        {
+            Console.WriteLine(_programHelp);
+            System.Environment.Exit(-1);
+        }
+
+        public static void Main(string[] args)
+        {
+            if (args.Length < 2)
+            {
+                PrintHelpAndExit();
+            }
+
+            string commandLine = null;
             
+            string subcommand = args[0];
+
+            if (_consoles.ContainsKey(subcommand))
+            {
+                commandLine = _consoles[subcommand];
+            }
+            else if (subcommand == "custom" && args.Length == 3)
+            {
+                commandLine = args[2];
+            }
+
+            string domainController = "";
+
+            string targetDomain = args[1];
+
+            if (targetDomain.ToLower().StartsWith("/gpobject:"))
+            {
+                commandLine = args.Aggregate(_gpmePath, (current, next) => $@"{current} {AddQuotesIfNeeded(next)}");
+
+                Uri uri = new Uri(targetDomain.Substring(10));
+                domainController = uri.Host;
+                targetDomain = domainController.Substring(domainController.IndexOf('.') + 1);
+
+                Console.WriteLine($"[=] Detected GPO edit action - DC={domainController}, TargetDomain={targetDomain}");
+            }
+
+            if (commandLine == null)
+            {
+                PrintHelpAndExit();
+            }
+
+            string channelName = null;
+
+            EasyHook.RemoteHooking.IpcCreateServer<DRSATHook.ServerRpc>(ref channelName, System.Runtime.Remoting.WellKnownObjectMode.Singleton);
+
             string injectionLibrary = Path.Combine(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().Location), "DRSATHook.dll");
 
-            EasyHook.RemoteHooking.CreateAndInject(@"c:\windows\system32\mmc.exe", commandLine, 0, EasyHook.InjectionOptions.DoNotRequireStrongName,
+            EasyHook.RemoteHooking.CreateAndInject(_mmcPath, commandLine, 0, EasyHook.InjectionOptions.DoNotRequireStrongName,
                 injectionLibrary, injectionLibrary, out var targetPID, new object[] { targetDomain, domainController, channelName });
 
             Console.WriteLine($"[+] Launched MMC with PID {targetPID}, waiting for process to exit...");
 
-            Process.GetProcessById(targetPID).WaitForExit();           
+            Process.GetProcessById(targetPID).WaitForExit();
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,48 +1,75 @@
-# Disconnected RSAT 
+# Disconnected RSAT
 
 ## Introduction
 
-Disconnected RSAT is a launcher for the official Group Policy Manager, Certificate Authority and Certificate Templates snap-in to bypass the domain joined requirement that is needed when using the official MMC snap-in.  
+Disconnected RSAT is a launcher for the official Group Policy Manager, Certificate Authority and Certificate Templates snap-in to bypass the domain joined requirement that is needed when using the official MMC snap-in.
 
-The tool works by injecting a C# library into MMC that will hook the various API calls to trick MMC into believing that the logged on user is a domain user.  Hooks are also placed on the `NtCreateFile` API to redirect file paths that would typically be resolved via DFS to a specific domain controller.
+The tool works by injecting a C# library into MMC that will hook the various API calls to trick MMC into believing that the logged on user is a domain user. Hooks are also placed on the `NtCreateFile` API to redirect file paths that would typically be resolved via DFS to a specific domain controller.
 
-## Prerequisites  
+## Prerequisites
 
 Since Disconnected RSAT relies on the official snap-ins, you'll first need to install the Windows Remote Server Administration Tools (RSAT) on the non domain joined host you'll be operating from.
 
 ## Usage
 
-mmc.exe is marked for auto elevation, therefore launching of `DRSAT.exe` should be performed from an elevated command prompt that has either got a relevant TGT with correct permissions imported into the same luid session or alternatively the session has been created using `runas /netonly`.  This will ensure that the relevant Kerberos tickets will be fetched automatically or NTLM credentials are used for outbound network connections when `runas /netonly` has been used.  
+`mmc.exe` is marked for auto elevation, therefore launching of `DRSAT.exe` should be performed from an elevated command prompt that has either got a relevant TGT with correct permissions imported into the same luid session or alternatively the session has been created using `runas /netonly`. This will ensure that the relevant Kerberos tickets will be fetched automatically or NTLM credentials are used for outbound network connections when `runas /netonly` has been used.
 
-### Launching Group Policy Manager
+### Launching ADSI Edit
+
+To launch ADSI Edit to target a specific Active Directory domain, simply supply the DNS domain name of the target. Some features of this snap-in (for example, Security tab) don't work properly without using DRSAT. 
+
+```
+DRSAT adsi ad.target.com
+```
+
+### Launching Active Directory Users and Computers
+
+To launch ADUC to target a specific Active Directory domain, simply supply the DNS domain name of the target. Some features of this snap-in (for example, Security tab) don't work properly without using DRSAT. 
+
+```
+DRSAT aduc ad.target.com
+```
+
+### Launching Group Policy Management
 
 To launch GPM to target a specific Active Directory domain, simply supply the DNS domain name of the target.
 
 ```
 DRSAT gpo ad.target.com
-``` 
+```
 
-### Launching Certificate Authority
+### Launching DNS Manager
 
-Whilst the certificate authority snap-in works when disconnected from the domain, template resolution doesn't work correctly, this can be solved by launching via DRSAT
+To launch DNS Manager to target a specific Active Directory domain, simply supply the DNS domain name of the target.
+
+```
+DRSAT dns ad.target.com
+```
+
+### Launching Certification Authority
+
+Whilst the Certification Authority snap-in works when disconnected from the domain, template resolution doesn't work correctly, this can be solved by launching via DRSAT.
 
 ```
 DRSAT cert ad.target.com
 ```
 
-### Launching Certifictate Template edittor
+### Launching Certificate Template Editor
 
-You can also directly edit certificate templates by using the following command
+You can also directly edit certificate templates by using the following command.
 
 ```
 DRSAT template ad.target.com
 ```
 
+### Launching custom snap-ins
+
+If there is no snap-in you need, you can specify the necessary one by using the following command.
+
+```
+DRSAT custom ad.target.com C:\Windows\System32\custom.msc
+```
+
 ### Release
 
-Precompiled binaries can be found on the [Releases](https://github.com/CCob/DRSAT/releases) page
-
-
-
-
-
+Precompiled binaries can be found on the [Releases](https://github.com/CCob/DRSAT/releases) page.


### PR DESCRIPTION
This PR introduces the following changes:

1. Support for custom snap-ins using the following syntax. 
  ```
  DRSAT custom ad.target.com C:\Windows\System32\custom.msc
  ```
2. Support for several other common snap-ins (ADSI Edit, ADUC, DNS Manager). 
3. Source code of DRSAT is formatted according to C# Coding Conventions. 
4. Several typos in `README.md` are fixed. 